### PR TITLE
Construct UI grid

### DIFF
--- a/App/0_grid.scd
+++ b/App/0_grid.scd
@@ -1,0 +1,382 @@
+// App/0_grid.scd — UNGRUND · GRID: генератор структурных сеток по канону
+// docs/architecture/structure-grid/README.md (правила 1–6).
+// Чистая логика, сервер не нужен. Грузится шагом 0a в 1_app.scd, сразу за
+// 0_lib.scd — окно микшера (шаг 4) читает ~gridGenerate.
+// API: ~gridGenerate.(complexity) -> ( text:, field:, nodes:, rows:, cols: )
+//      или nil при отказе; ~gridRender.(grid) -> строка поля.
+// Алфавит символов: docs/architecture/structure-grid/char.md.
+
+(
+// ===== CONFIG — edit here ============================================
+// Между парой [a, b] интерполирует слайдер сложности 0..1.
+~cfg_grid = (
+    nodes:      [5, 24],        // число Ф при сложности 0 -> 1
+    branchProb: [0.15, 0.60],   // вероятность ветвления Ф (правило 4)
+    mergeProb:  [0.10, 0.50],   // вероятность схождения двух ветвей в один Ф
+    maxOut:     3,              // максимум исходящих связей из узла
+    // Потолок ширины фронта. Растеризатор разводит связи только сегментами и
+    // углами (тройники/кресты канон резервирует), и фронт шире 5 на плоскости
+    // без пересечений почти не разводится. Без потолка такие графы всё равно
+    // отбраковывались бы — но молча, смещая выборку в сторону узких.
+    maxFront:   [3, 5],         // ширина фронта при сложности 0 -> 1
+    cols:       [16, 64],       // ширина поля  (канон: 16 … 64)
+    rows:       [16, 64],       // высота поля  (канон: 16 … 64)
+    // Шаг рангов по строкам НЕ фиксирован: он выводится из числа рангов графа
+    // так, чтобы граф занял поле по высоте (rowGap = (rows-2) div (tiers-1),
+    // зажат в [rowGapMin, rowGapMax]). Фиксированный шаг молча отбраковывал по
+    // высоте целые классы графов — стволовые, — и ретрай подменял их широкими:
+    // выборка смещалась. rowGap-1 = число полос для горизонтальных перекладин,
+    // поэтому широкий низкий граф получает много полос и разводится.
+    rowGapMin:  2,              // правило 3: между рангами хотя бы одна связь
+    rowGapMax:  8,              // потолок шага (длиннее связи не растягиваем)
+    colGap:     4,              // шаг узлов по колонкам   (>= 3: боковые выходы)
+    relax:      4,              // сглаживающих проходов раскладки (короче связи)
+    rasterTries: 8,             // попыток развести ОДИН граф (перебор полос)
+    graphTries: 40              // попыток вырастить новый граф до отказа
+);
+
+
+// ===== LOGIC — граф, раскладка, растеризация =========================
+// алфавит канона: Ф свободны, связи — только прямые сегменты и углы
+// (тройники, кресты и переходные символы канон резервирует)
+~gridFillChars = ["░", "▒", "▓", "█", "▄"];
+~gridLineChars = (
+    weak: (
+        vert: "│", horiz: "─",
+        upRight: "└", upLeft: "┘", downRight: "┌", downLeft: "┐"
+    ),
+    strong: (
+        vert: "║", horiz: "═",
+        upRight: "╚", upLeft: "╝", downRight: "╔", downLeft: "╗"
+    )
+);
+
+~gridLerp = { |pair, t| pair[0] + ((pair[1] - pair[0]) * t) };
+
+// (a..b) в SC при a > b идёт ВНИЗ и возвращает непустой ряд — на вырожденных
+// сегментах связи это рисовало бы лишние ячейки поверх соседних
+~gridSpan = { |a, b| if(a > b) { [] } { (a .. b) } };
+
+~gridMedian = { |vals|
+    var s = vals.asArray.sort;
+    var m = s.size div: 2;
+    if(s.size.odd) { s[m] } { (s[m - 1] + s[m]) / 2 };
+};
+
+~gridRender = { |grid|
+    grid[\field].collect { |row|
+        var s = row.join("");
+        var i = s.size - 1;
+        while { i >= 0 and: { s[i] == $  } } { i = i - 1 };
+        if(i < 0) { "" } { s.copyRange(0, i) };
+    }.join("\n");
+};
+
+// ----- граф по рангам (этап 1) + сила связи (этап 2) -----------------
+~gridGrow = { |target, branchProb, mergeProb, maxFront|
+    var nodes = List[];
+    var edges = List[];
+    var mkNode, addEdge, frontier, tier, root;
+
+    mkNode = { |t|
+        var n = (tier: t, ins: List[], outs: List[], col: 0, ch: ~gridFillChars.choose);
+        nodes.add(n); n;
+    };
+    addEdge = { |a, b|
+        var e = (src: a, dst: b, strong: true, exitSide: \down, entrySide: \up);
+        edges.add(e); a.outs.add(e); b.ins.add(e); e;
+    };
+
+    root = mkNode.(0);
+    frontier = [root];
+    tier = 0;
+
+    while { nodes.size < target and: { frontier.size > 0 } } {
+        var slots = List[];
+        var kids = List[];
+        var i = 0;
+        var budget = target - nodes.size;
+        var room = maxFront;
+        var ods = Array.fill(frontier.size, 0);
+        // порядок РОЗЫГРЫША od случаен, порядок слотов — фронтовой: иначе
+        // остаток room доставался бы всегда левым Ф и структура кренилась влево
+        (0 .. frontier.size - 1).scramble.do { |ix|
+            var n = frontier[ix];
+            // суммарная степень Ф <= 4: у ячейки ровно четыре соседа, каждая
+            // связь занимает ровно один из них (ветвление в Ф — правило 4)
+            var cap = ~cfg_grid.maxOut.min(4 - n.ins.size).min(budget).min(room);
+            // бюджет/фронт исчерпан -> od = 0: Ф остаётся листовым (правило 5),
+            // иначе фронт растёт по экспоненте и никакое поле его не вмещает.
+            // Корень не ветвится: правило 2 даёт ему ровно ОДНУ первую связь, а
+            // правило 6 требует непустого ствола до первого ветвящегося Ф.
+            // rrand(2, cap) при cap = 1 вернул бы 2 (rrand симметричен по
+            // порядку аргументов) — ветвимся только когда cap это позволяет.
+            var od = if(cap < 1) { 0 } {
+                if(n !== root and: { cap >= 2 } and: { branchProb.coin }) {
+                    rrand(2, cap)
+                } { 1 };
+            };
+            ods[ix] = od;
+            budget = budget - od;
+            room = room - od;
+        };
+        frontier.do { |n, ix| ods[ix].do { slots.add(n) } };
+        while { i < slots.size } {
+            var kid = mkNode.(tier + 1);
+            addEdge.(slots[i], kid);
+            if(
+                (i + 1 < slots.size)
+                and: { slots[i + 1] !== slots[i] }
+                and: { mergeProb.coin }
+            ) {
+                addEdge.(slots[i + 1], kid);
+                i = i + 2;
+            } {
+                i = i + 1;
+            };
+            kids.add(kid);
+        };
+        frontier = kids.asArray;
+        tier = tier + 1;
+    };
+
+    // правило 6: схождение приоритетнее ветвления; узлы идут в порядке рангов,
+    // поэтому сила входящей связи уже известна
+    nodes.do { |n|
+        var strong = case
+            { n.ins.size >= 2 } { true }
+            { n.outs.size >= 2 } { false }
+            { n.ins.size == 0 } { true }
+            { true } { n.ins[0].strong };
+        n.outs.do { |e| e.strong = strong };
+    };
+
+    ( nodes: nodes.asArray, edges: edges.asArray, tiers: tier + 1 )
+};
+
+// ----- раскладка (этап 3) --------------------------------------------
+// Ряд разводится с шагом colGap и ставится на СРЕДНЮЮ желаемую колонку, а не
+// по центру поля: центрирование каждого ранга отдельно уводит Ф от родителей,
+// и связям остаются длинные горизонтальные перекладины, которым не хватает
+// двух свободных строк зазора — растеризация захлёбывается коллизиями
+// Порядок узлов в ряду НЕ сортируется по желаемой колонке: узлы рождаются
+// слева направо (слоты идут по порядку фронта), и этот порядок — плоское
+// вложение графа. Пересортировка меняет вложение, ветви начинают пересекаться,
+// а пересечение требует ┼/╬, которых канон не даёт => сплошной отказ
+~gridPlaceTier = { |arr, desired, cols|
+    var lo, hi, shift;
+    arr.do { |n, i|
+        var c = desired[i];
+        if(i > 0) { c = c.max(arr[i - 1].col + ~cfg_grid.colGap) };
+        n.col = c;
+    };
+    shift = (desired.mean - arr.collect { |n| n.col }.mean).round.asInteger;
+    arr.do { |n| n.col = n.col + shift };
+    lo = arr.first.col;
+    if(lo < 1) { arr.do { |n| n.col = n.col + (1 - lo) } };
+    hi = arr.last.col;
+    if(hi > (cols - 2)) { arr.do { |n| n.col = n.col - (hi - (cols - 2)) } };
+    arr;
+};
+
+~gridLayout = { |graph, cols|
+    var byTier = Array.fill(graph[\tiers], { List[] });
+    var top = graph[\tiers] - 1;
+    var downSweep, upSweep;
+    graph[\nodes].do { |n| byTier[n.tier].add(n) };
+    byTier = byTier.collect(_.asArray);
+    byTier[0][0].col = (cols / 2).floor.asInteger;
+
+    downSweep = {
+        ~gridSpan.(1, top).do { |t|
+            byTier[t] = ~gridPlaceTier.(
+                byTier[t],
+                byTier[t].collect { |n|
+                    ~gridMedian.(n.ins.collect { |e| e.src.col }).round.asInteger
+                },
+                cols
+            );
+        };
+    };
+    upSweep = {
+        ~gridSpan.(0, top - 1).reverse.do { |t|
+            byTier[t] = ~gridPlaceTier.(
+                byTier[t],
+                byTier[t].collect { |n|
+                    if(n.outs.isEmpty) { n.col } {
+                        ~gridMedian.(n.outs.collect { |e| e.dst.col }).round.asInteger
+                    };
+                },
+                cols
+            );
+        };
+    };
+
+    downSweep.value;
+    ~cfg_grid.relax.do { upSweep.value; downSweep.value };
+    byTier;
+};
+
+// ----- стороны Ф: каждая связь занимает ровно одного соседа ----------
+// входящая никогда не берёт \down, исходящая никогда не берёт \up —
+// иначе связь шла бы против направления развития (сверху вниз)
+~gridSides = { |graph|
+    var ok = true;
+    var pick = { |cands, used|
+        var side = cands.detect { |s| used[s].isNil };
+        if(side.isNil) { ok = false } { used[side] = true };
+        side ? \down;
+    };
+    var order = { |dc, alt|
+        var sides = if(dc < 0) { [\left, \right] } { if(dc > 0) { [\right, \left] } { [\left, \right] } };
+        sides ++ [alt];
+    };
+    graph[\nodes].do { |n|
+        var used = ();
+        var insA  = n.ins.asArray.sort  { |a, b| (a.src.col - n.col).abs < (b.src.col - n.col).abs };
+        var outsA = n.outs.asArray.sort { |a, b| (a.dst.col - n.col).abs < (b.dst.col - n.col).abs };
+        insA.do { |e, i|
+            var dc = e.src.col - n.col;
+            var cands = if(i == 0) { [\up] ++ order.(dc, \up) } { order.(dc, \up) };
+            e.entrySide = pick.(cands, used);
+        };
+        outsA.do { |e, i|
+            var dc = e.dst.col - n.col;
+            var cands = if(i == 0) { [\down] ++ order.(dc, \down) } { order.(dc, \down) };
+            e.exitSide = pick.(cands, used);
+        };
+    };
+    ok;
+};
+
+// ----- растеризация (этап 4) + проверки (этап 5) ---------------------
+// Граф приходит готовым: раскладка и проверки детерминированы, случаен только
+// выбор полосы под перекладину. Поэтому неудачную разводку перебираем НА ТОМ ЖЕ
+// графе (rasterTries) и только потом отдаём его назад — иначе отбраковка по
+// коллизии выбивает целые классы графов (широкие низкие) и смещает выборку.
+~gridAttempt = { |graph, cols, rows|
+    var field;
+    var ok = true;
+    var rowGap, rowOf, cells, place, edgesByReach, routed, pass;
+
+    // шаг рангов под конкретный граф: стволовой сжимается до rowGapMin и влезает
+    // по высоте, низкий растягивается до rowGapMax и получает полосы под
+    // перекладины. Так отбраковка по высоте не выбивает стволовые графы.
+    rowGap = if(graph[\tiers] > 1) {
+        ((rows - 2) div: (graph[\tiers] - 1)).clip(~cfg_grid.rowGapMin, ~cfg_grid.rowGapMax)
+    } { ~cfg_grid.rowGapMax };
+
+    rowOf = { |n| 1 + (n.tier * rowGap) };
+
+    // недостижимо при канонных nodes/rows, но CONFIG правится руками:
+    // высокий target на низком поле не влезает даже при rowGapMin
+    if(1 + ((graph[\tiers] - 1) * rowGap) > (rows - 1)) { ok = false };
+
+    if(ok) { ~gridLayout.(graph, cols) };
+    if(ok) {
+        graph[\nodes].do { |n|
+            if(n.col < 1 or: { n.col > (cols - 2) }) { ok = false };
+        };
+    };
+
+    // правило 3: расстояние Чебышёва между любыми двумя Ф >= 2
+    if(ok) {
+        graph[\nodes].do { |a, i|
+            graph[\nodes].do { |b, j|
+                if(i < j) {
+                    var d = (rowOf.(a) - rowOf.(b)).abs.max((a.col - b.col).abs);
+                    if(d < 2) { ok = false };
+                };
+            };
+        };
+    };
+
+    if(ok) { ok = ~gridSides.(graph) };
+
+    cells = { |e, j|
+        var n1 = e.src, n2 = e.dst;
+        var r1 = rowOf.(n1), r2 = rowOf.(n2);
+        var g = if(e.strong) { ~gridLineChars.strong } { ~gridLineChars.weak };
+        var out = List[];
+        var x, y;
+        case
+            { e.exitSide == \left }  { x = n1.col - 1; out.add([r1, x, g.downRight]) }
+            { e.exitSide == \right } { x = n1.col + 1; out.add([r1, x, g.downLeft]) }
+            { true }                 { x = n1.col };
+        case
+            { e.entrySide == \left }  { y = n2.col - 1; out.add([r2, y, g.upRight]) }
+            { e.entrySide == \right } { y = n2.col + 1; out.add([r2, y, g.upLeft]) }
+            { true }                  { y = n2.col };
+        if(x == y) {
+            ~gridSpan.(r1 + 1, r2 - 1).do { |r| out.add([r, x, g.vert]) };
+        } {
+            ~gridSpan.(r1 + 1, j - 1).do { |r| out.add([r, x, g.vert]) };
+            out.add([j, x, if(y > x) { g.upRight } { g.upLeft }]);
+            ~gridSpan.(x.min(y) + 1, x.max(y) - 1).do { |c| out.add([j, c, g.horiz]) };
+            out.add([j, y, if(y > x) { g.downLeft } { g.downRight }]);
+            ~gridSpan.(j + 1, r2 - 1).do { |r| out.add([r, y, g.vert]) };
+        };
+        out;
+    };
+
+    // коллизия = пересечение связей, которое потребовало бы ┼/╬ — канон их не
+    // даёт, поэтому пишем только целиком свободный маршрут
+    place = { |list|
+        var free = list.every { |t|
+            (t[0] >= 0) and: { t[0] < rows } and: { t[1] >= 0 } and: { t[1] < cols }
+                and: { field[t[0]][t[1]] == " " };
+        };
+        if(free) { list.do { |t| field[t[0]][t[1]] = t[2] } };
+        free;
+    };
+
+    edgesByReach = graph[\edges].sort { |a, b|
+        (a.src.col - a.dst.col).abs > (b.src.col - b.dst.col).abs
+    };
+
+    pass = {
+        var fine = true;
+        field = Array.fill(rows, { Array.fill(cols, " ") });
+        graph[\nodes].do { |n| if(place.([[rowOf.(n), n.col, n.ch]]).not) { fine = false } };
+        edgesByReach.do { |e|
+            if(fine) {
+                var lanes = ~gridSpan.(rowOf.(e.src) + 1, rowOf.(e.dst) - 1).scramble;
+                var done = false;
+                lanes.do { |j| if(done.not) { done = place.(cells.(e, j)) } };
+                if(done.not) { fine = false };
+            };
+        };
+        fine;
+    };
+
+    if(ok) {
+        var n = 0;
+        routed = false;
+        while { routed.not and: { n < ~cfg_grid.rasterTries } } {
+            n = n + 1;
+            routed = pass.value;
+        };
+        ok = routed;
+    };
+
+    if(ok) { ( field: field, nodes: graph[\nodes].size, rows: rows, cols: cols ) };
+};
+
+~gridGenerate = { |complexity = 0.5|
+    var t = complexity.clip(0, 1);
+    var target = ~gridLerp.(~cfg_grid[\nodes], t).round.asInteger.max(2);
+    var bp   = ~gridLerp.(~cfg_grid[\branchProb], t);
+    var mp   = ~gridLerp.(~cfg_grid[\mergeProb], t);
+    var cols = ~gridLerp.(~cfg_grid[\cols], t).round.asInteger;
+    var rows = ~gridLerp.(~cfg_grid[\rows], t).round.asInteger;
+    var mf = ~gridLerp.(~cfg_grid[\maxFront], t).round.asInteger.max(1);
+    var got = nil, n = 0;
+    while { got.isNil and: { n < ~cfg_grid.graphTries } } {
+        n = n + 1;
+        got = ~gridAttempt.(~gridGrow.(target, bp, mp, mf), cols, rows);
+    };
+    got !? { got[\text] = ~gridRender.(got); got };
+};
+
+"0_grid — генератор структурных сеток (~gridGenerate / ~gridRender).".postln;
+)

--- a/App/1_app.scd
+++ b/App/1_app.scd
@@ -54,6 +54,9 @@ s.waitForBoot({
 
     // 0a. tuning infrastructure first: synths/*.scd register specs in ~ungSpecs
     (~appDir +/+ "0_lib.scd").load;
+    // structure-grid generator: pure logic, no server; the mixer window (step 4)
+    // reads ~gridGenerate, so it must exist before the mixer is loaded
+    (~appDir +/+ "0_grid.scd").load;
 
     // 0b. clean start
     ~appCleanup.value(false);

--- a/App/1_app.scd
+++ b/App/1_app.scd
@@ -42,9 +42,10 @@
         ~seqClock.stop;
         ~seqClock = nil;
     };
-    if(~busDry.notNil)      { ~busDry.free;      ~busDry = nil };
-    if(~busFxSend.notNil)   { ~busFxSend.free;   ~busFxSend = nil };
-    if(~busFxReturn.notNil) { ~busFxReturn.free; ~busFxReturn = nil };
+    if(~busDry.notNil)        { ~busDry.free;        ~busDry = nil };
+    if(~busFxSendRev.notNil)  { ~busFxSendRev.free;  ~busFxSendRev = nil };
+    if(~busFxSendDly.notNil)  { ~busFxSendDly.free;  ~busFxSendDly = nil };
+    if(~busFxReturn.notNil)   { ~busFxReturn.free;   ~busFxReturn = nil };
     s.freeAll;
     if(verbose) { "UNGRUND app — очистка выполнена.".postln };
 };
@@ -58,9 +59,13 @@ s.waitForBoot({
     ~appCleanup.value(false);
 
     // 1. buses
-    ~busDry      = Bus.audio(s, 2);   // dry layer sum -> master
-    ~busFxSend   = Bus.audio(s, 2);   // layer sends -> effects (§K)
-    ~busFxReturn = Bus.audio(s, 2);   // effect returns -> master (§K)
+    ~busDry       = Bus.audio(s, 2);   // dry layer sum -> master
+    // two send buses, NOT one: §K.1 and §K.2 prescribe independent per-class
+    // send tables (delta/epsilon/zeta: reverb yes, delay 0.0) — a shared bus
+    // cannot express that, since both effects would read the same sum
+    ~busFxSendRev = Bus.audio(s, 2);   // layer sends -> \tape_reverb (§K.1)
+    ~busFxSendDly = Bus.audio(s, 2);   // layer sends -> \ping_delay  (§K.2)
+    ~busFxReturn  = Bus.audio(s, 2);   // effect returns -> master (§K)
     s.sync;
 
     // 2. synth layers (optional filter via ~cfg_app.layers)
@@ -107,7 +112,7 @@ s.waitForBoot({
         };
     };
 
-    // 3. effects (read ~busFxSend, write ~busFxReturn)
+    // 3. effects (read ~busFxSendRev/~busFxSendDly, write ~busFxReturn)
     if(~cfg_app.enableEffects) {
         (~appDir +/+ "6_effects.scd").load;
         s.sync;

--- a/App/2_mixer.scd
+++ b/App/2_mixer.scd
@@ -1,32 +1,34 @@
-// App/2_mixer.scd — UNGRUND · MIXER: per-layer vol/send routing, fx-send
-// aggregator, master (LeakDC + Limiter), solo, recorder, mixer window.
+// App/2_mixer.scd — UNGRUND · MIXER: per-layer vol + two fx sends (reverb
+// §K.1 / delay §K.2), one aggregator per send bus, master (LeakDC +
+// Limiter), solo, recorder, mixer window.
 // Routes only layers listed in ~activeLayers (set by 1_app.scd).
 // Signal flow: docs/architecture/app/README.md.
 
 
 // ===== CONFIG — edit here ============================================
 (
-// Level table, key = layer name. vol = level into master, send = fx send
-// (§K.1/K.2 recommended levels as a start). Entries for unloaded layers
-// are simply ignored.
+// Level table, key = layer name. vol = level into master; sendRev = tape
+// reverb send (§K.1 table), sendDly = ping-pong delay send (§K.2 table).
+// The two sends are independent by canon — see the aggregators below.
+// Entries for unloaded layers are simply ignored.
 ~cfg_mixer = (
     master:  0.9,
 
     levels: (
-        //            vol    send
-        alpha:   ( vol: 0.85, send: 0.55 ),
-        beta:    ( vol: 0.00, send: 0.00 ),          // stub — off
-        gamma:   ( vol: 0.80, send: 0.35 ),          // §K.1 flockung; the send is the drips' ONLY space
-        delta:   ( vol: 0.80, send: 0.45 ),
-        epsilon: ( vol: 0.75, send: 0.15 ),          // §K.1: self-diffuse — low send
-        zeta:    ( vol: 0.75, send: 0.15 ),
-        eta:     ( vol: 0.00, send: 0.00 ),          // silence — no level
-        theta:   ( vol: 0.00, send: 0.00 )           // stub — off
+        //            vol    sendRev (§K.1)  sendDly (§K.2)
+        alpha:   ( vol: 0.85, sendRev: 0.55, sendDly: 0.20 ),
+        beta:    ( vol: 0.00, sendRev: 0.00, sendDly: 0.00 ),   // stub — off
+        gamma:   ( vol: 0.80, sendRev: 0.35, sendDly: 0.20 ),   // §K.1 flockung; the send is the drips' ONLY space
+        delta:   ( vol: 0.80, sendRev: 0.45, sendDly: 0.00 ),   // §K.2: binde is not in the delay table
+        epsilon: ( vol: 0.75, sendRev: 0.15, sendDly: 0.00 ),   // §K.1: self-diffuse — low send; §K.2: no delay
+        zeta:    ( vol: 0.75, sendRev: 0.15, sendDly: 0.00 ),   // §K.2: kratzer is not in the delay table
+        eta:     ( vol: 0.00, sendRev: 0.00, sendDly: 0.00 ),   // silence — no level
+        theta:   ( vol: 0.00, sendRev: 0.00, sendDly: 0.00 )    // stub — off
     )
 );
 
 // fallback levels for a layer missing from the table (new synths/*.scd)
-~mixerDefaultLevel = ( vol: 0.7, send: 0.0 );
+~mixerDefaultLevel = ( vol: 0.7, sendRev: 0.0, sendDly: 0.0 );
 
 // master-sum recorder: file format and dir (relative to project root)
 ~cfg_recorder = ( header: "wav", sample: "int24", dir: "recordings" );
@@ -56,21 +58,36 @@
     Ndef(routerKey).play(out: ~busDry.index, numChannels: 2);
 };
 
-// send aggregator: sum of all layers × send -> ~busFxSend.
-// Sole writer of the send bus; ReplaceOut => no accumulation across blocks.
-Ndef(\fxsend, {
-    var sends = ~mixerLayers.collect { |layer|
+// send aggregators: ONE PER EFFECT BUS, so the §K.1 and §K.2 send tables stay
+// independent — a layer may go to the reverb and NOT to the delay, which a
+// single shared send bus cannot express (both effects would read one sum).
+// Each aggregator is the SOLE writer of its bus; ReplaceOut => no
+// accumulation across blocks.
+// both aggregators expose the SAME param names (send_<layer>) — the Ndef they
+// live on is what distinguishes the §K.1 send from the §K.2 send
+~mixerSendMix = {
+    Mix(~mixerLayers.collect { |layer|
         var amt = NamedControl.kr(("send_" ++ layer).asSymbol, 0);
         Ndef(layer.asSymbol).ar(2) * amt.lag(0.1);
-    };
-    ReplaceOut.ar(~busFxSend.index, Mix(sends));
-});
-~mixerLayers.do { |layer|
-    Ndef(\fxsend).set(("send_" ++ layer).asSymbol, ~cfg_mixer.levels[layer].send);
+    })
 };
-Ndef(\fxsend).fadeTime = 1;
-// NO .play: the proxy body already writes via ReplaceOut; a monitor would
-// add a SECOND writer mixing the empty proxy bus on top of ReplaceOut
+
+Ndef(\fxsendRev, { ReplaceOut.ar(~busFxSendRev.index, ~mixerSendMix.value) });
+Ndef(\fxsendDly, { ReplaceOut.ar(~busFxSendDly.index, ~mixerSendMix.value) });
+
+// which -> aggregator Ndef key (~mixSet/~mixSolo/~mixUnsolo lookup)
+~mixerSendAgg = ( sendRev: \fxsendRev, sendDly: \fxsendDly );
+
+~mixerSendAgg.keysValuesDo { |which, aggKey|
+    ~mixerLayers.do { |layer|
+        Ndef(aggKey).set(
+            ("send_" ++ layer).asSymbol, ~cfg_mixer.levels[layer][which]
+        );
+    };
+    Ndef(aggKey).fadeTime = 1;
+    // NO .play: the proxy body already writes via ReplaceOut; a monitor would
+    // add a SECOND writer mixing the empty proxy bus on top of ReplaceOut
+};
 
 // master: (dry + fx return), LeakDC, Limiter
 Ndef(\master, { |amp = 0.9|
@@ -93,11 +110,13 @@ Ndef(\master).play(out: 0, numChannels: 2);
 ~mixerGuiSync = ~mixerGuiSync;
 
 // live setters for editing / MIDI / sequencer:
-// ~mixSet.(\alpha, \vol, 0.5) / ~mixSet.(\theta, \send, 0.8) / ~masterSet.(v)
+// ~mixSet.(\alpha, \vol, 0.5) / ~mixSet.(\alpha, \sendRev, 0.8)
+// / ~mixSet.(\alpha, \sendDly, 0.2) / ~masterSet.(v)
 ~mixSet = { |layer, which = \vol, value|
+    var agg = ~mixerSendAgg[which];
     if(~cfg_mixer.levels[layer].isNil) { ~cfg_mixer.levels[layer] = ~mixerDefaultLevel.copy };
-    if(which == \send) {
-        Ndef(\fxsend).set(("send_" ++ layer).asSymbol, value);
+    if(agg.notNil) {
+        Ndef(agg).set(("send_" ++ layer).asSymbol, value);
     } {
         Ndef(("mix_" ++ layer).asSymbol).set(\vol, value);
     };
@@ -116,7 +135,9 @@ Ndef(\master).play(out: 0, numChannels: 2);
         var on = (l == layer);
         var lv = ~cfg_mixer.levels[l];
         Ndef(("mix_" ++ l).asSymbol).set(\vol, on.if({ lv.vol }, 0));
-        Ndef(\fxsend).set(("send_" ++ l).asSymbol, on.if({ lv.send }, 0));
+        ~mixerSendAgg.keysValuesDo { |which, agg|
+            Ndef(agg).set(("send_" ++ l).asSymbol, on.if({ lv[which] }, 0));
+        };
     };
     ~mixSoloCur = layer;
     if(~mixerRefreshSolo.notNil) { ~mixerRefreshSolo.value };
@@ -125,7 +146,9 @@ Ndef(\master).play(out: 0, numChannels: 2);
     ~mixerLayers.do { |l|
         var lv = ~cfg_mixer.levels[l];
         Ndef(("mix_" ++ l).asSymbol).set(\vol, lv.vol);
-        Ndef(\fxsend).set(("send_" ++ l).asSymbol, lv.send);
+        ~mixerSendAgg.keysValuesDo { |which, agg|
+            Ndef(agg).set(("send_" ++ l).asSymbol, lv[which]);
+        };
     };
     ~mixSoloCur = nil;
     if(~mixerRefreshSolo.notNil) { ~mixerRefreshSolo.value };
@@ -170,7 +193,7 @@ Ndef(\master).play(out: 0, numChannels: 2);
 
 // ===== GUI — mixer window ============================================
 // widget registries (idempotent on file reload)
-~mixerEz      = ();    // layer -> ( \vol: EZSlider, \send: EZSlider ); \master -> EZSlider
+~mixerEz      = ();    // layer -> ( \vol:, \sendRev:, \sendDly: EZSlider ); \master -> EZSlider
 ~mixerSoloBtn = ();    // layer -> Button (solo)
 ~mixSoloCur   = ~mixSoloCur;   // current solo layer (or nil), survives reopen
 
@@ -187,7 +210,7 @@ Ndef(\master).play(out: 0, numChannels: 2);
     layers = ~mixerLayers;
     rowH = 30; y0 = 74;
     by = y0 + (layers.size * rowH) + 14;
-    w  = 812; h = by + 40 + 40;
+    w  = 954; h = by + 40 + 40;
 
     // close previous window best-effort (reference may be a destroyed Qt
     // object; .close without try would abort the rebuild — same as tuner)
@@ -206,12 +229,14 @@ Ndef(\master).play(out: 0, numChannels: 2);
     ~mixerWin = win;
 
     StaticText(~mixerWin, Rect(18, 10, w - 36, 22))
-        .string_("сведение слоёв — vol в мастер · send в эффекты · solo · tuner (живой Ndef)")
+        .string_("сведение слоёв — vol в мастер · rev/dly посылы в эффекты · solo · tuner (живой Ndef)")
         .stringColor_(Color.gray(0.92)).font_(Font("Menlo", 13, true));
 
-    StaticText(~mixerWin, Rect(112, 50, 250, 16)).string_("vol -> master")
+    StaticText(~mixerWin, Rect(112, 50, 210, 16)).string_("vol -> master")
         .stringColor_(Color.gray(0.6)).font_(Font("Menlo", 9));
-    StaticText(~mixerWin, Rect(372, 50, 250, 16)).string_("send -> fx")
+    StaticText(~mixerWin, Rect(332, 50, 210, 16)).string_("rev -> tape reverb (§K.1)")
+        .stringColor_(Color.gray(0.6)).font_(Font("Menlo", 9));
+    StaticText(~mixerWin, Rect(552, 50, 210, 16)).string_("dly -> ping-pong (§K.2)")
         .stringColor_(Color.gray(0.6)).font_(Font("Menlo", 9));
 
     // one row per layer
@@ -219,23 +244,28 @@ Ndef(\master).play(out: 0, numChannels: 2);
         var y = y0 + (i * rowH);
         var lv = ~cfg_mixer.levels[layer] ? ~mixerDefaultLevel;
         var hasSpec = ~ungSpecOf.notNil and: { ~ungSpecOf.(layer).notNil };
-        var ezV, ezS, soloBtn, tunBtn;
+        var ezV, ezR, ezD, soloBtn, tunBtn;
 
         StaticText(~mixerWin, Rect(16, y, 92, 24))
             .string_(layer.asString)
             .stringColor_(Color.gray(0.9)).font_(Font("Menlo", 12, true));
 
-        ezV = EZSlider(~mixerWin, Rect(112, y, 250, 24), "vol",
+        ezV = EZSlider(~mixerWin, Rect(112, y, 210, 24), "vol",
             ControlSpec(0, 1, \lin, 0, lv.vol),
             { |ez| ~mixSet.(layer, \vol, ez.value) }, lv.vol);
         ezV.round_(0.001);
 
-        ezS = EZSlider(~mixerWin, Rect(372, y, 250, 24), "send",
-            ControlSpec(0, 1, \lin, 0, lv.send),
-            { |ez| ~mixSet.(layer, \send, ez.value) }, lv.send);
-        ezS.round_(0.001);
+        ezR = EZSlider(~mixerWin, Rect(332, y, 210, 24), "rev",
+            ControlSpec(0, 1, \lin, 0, lv.sendRev),
+            { |ez| ~mixSet.(layer, \sendRev, ez.value) }, lv.sendRev);
+        ezR.round_(0.001);
 
-        soloBtn = Button(~mixerWin, Rect(632, y, 56, 24))
+        ezD = EZSlider(~mixerWin, Rect(552, y, 210, 24), "dly",
+            ControlSpec(0, 1, \lin, 0, lv.sendDly),
+            { |ez| ~mixSet.(layer, \sendDly, ez.value) }, lv.sendDly);
+        ezD.round_(0.001);
+
+        soloBtn = Button(~mixerWin, Rect(772, y, 56, 24))
             .states_([
                 ["solo", Color.gray(0.9),  Color.gray(0.26)],
                 ["SOLO", Color.white,      Color(0.55, 0.42, 0.16)]
@@ -244,7 +274,7 @@ Ndef(\master).play(out: 0, numChannels: 2);
             .action_({ ~mixSoloToggle.(layer) });
         soloBtn.value_(if(~mixSoloCur == layer) { 1 } { 0 });
 
-        tunBtn = Button(~mixerWin, Rect(694, y, 100, 24))
+        tunBtn = Button(~mixerWin, Rect(836, y, 100, 24))
             .states_([["tuner", Color.white, Color(0.18, 0.34, 0.44)]])
             .font_(Font("Menlo", 11, true))
             .action_({ ~openTuner.(layer) });
@@ -254,7 +284,7 @@ Ndef(\master).play(out: 0, numChannels: 2);
                 .enabled_(false);
         };
 
-        ~mixerEz[layer]      = ( vol: ezV, send: ezS );
+        ~mixerEz[layer]      = ( vol: ezV, sendRev: ezR, sendDly: ezD );
         ~mixerSoloBtn[layer] = soloBtn;
     };
     layers.do { |layer, i| mkRow.(layer, i) };
@@ -262,20 +292,20 @@ Ndef(\master).play(out: 0, numChannels: 2);
     // --- master row + buttons ---
     StaticText(~mixerWin, Rect(16, by, 92, 24))
         .string_("master").stringColor_(Color.white).font_(Font("Menlo", 12, true));
-    masterEz = EZSlider(~mixerWin, Rect(112, by, 250, 24), "amp",
+    masterEz = EZSlider(~mixerWin, Rect(112, by, 210, 24), "amp",
         ControlSpec(0, 1, \lin, 0, ~cfg_mixer.master),
         { |ez| ~masterSet.(ez.value) }, ~cfg_mixer.master);
     masterEz.round_(0.001);
     ~mixerEz[\master] = masterEz;
 
-    Button(~mixerWin, Rect(372, by, 130, 24))
+    Button(~mixerWin, Rect(332, by, 130, 24))
         .states_([["all / unsolo", Color.gray(0.95), Color.gray(0.28)]])
         .font_(Font("Menlo", 11, true))
         .action_({ ~mixUnsolo.value });
 
     // record button state lives in ~mixRecOn, so it stays correct after
     // close/reopen while recording
-    recBtn = Button(~mixerWin, Rect(512, by, 110, 24))
+    recBtn = Button(~mixerWin, Rect(472, by, 110, 24))
         .states_([
             ["● rec",  Color.gray(0.9), Color.gray(0.26)],
             ["■ REC",  Color.white,     Color(0.62, 0.14, 0.14)]
@@ -284,7 +314,7 @@ Ndef(\master).play(out: 0, numChannels: 2);
         .action_({ ~mixRecToggle.value });
     recBtn.value_(if(~mixRecOn) { 1 } { 0 });
     ~mixerRecBtn = recBtn;
-    Button(~mixerWin, Rect(694, by, 100, 24))
+    Button(~mixerWin, Rect(836, by, 100, 24))
         .states_([["закрыть", Color.gray(0.9), Color(0.4, 0.18, 0.18)]])
         .font_(Font("Menlo", 11))
         .action_({ win.close });

--- a/App/2_mixer.scd
+++ b/App/2_mixer.scd
@@ -197,6 +197,12 @@ Ndef(\master).play(out: 0, numChannels: 2);
 ~mixerSoloBtn = ();    // layer -> Button (solo)
 ~mixSoloCur   = ~mixSoloCur;   // current solo layer (or nil), survives reopen
 
+// structure-grid panel slots (0_grid.scd may be absent — panel is nil-safe)
+~mixerGridTxt    = nil;   // TextView (поле)
+~mixerGridStatus = nil;   // StaticText (число Ф / размер поля / отказ)
+~mixerGridEz     = nil;   // EZSlider (сложность)
+~gridComplexity  = ~gridComplexity ? 0.5;   // survives reopen / missing 0_grid
+
 // update all solo-button visuals from ~mixSoloCur
 ~mixerRefreshSolo = {
     { ~mixerSoloBtn.keysValuesDo { |layer, btn|
@@ -206,21 +212,34 @@ Ndef(\master).play(out: 0, numChannels: 2);
 
 ~ungBuildMixer = {
     var layers, rowH, y0, w, h, by, mkRow, masterEz, recBtn;
+    var gx, gw, gh, hasGrid, gridTv, gridEz, gridStatus, gridBtn;
     var win;   // local capture: closures must not depend on the global slot
     layers = ~mixerLayers;
     rowH = 30; y0 = 74;
     by = y0 + (layers.size * rowH) + 14;
-    w  = 954; h = by + 40 + 40;
+    // окно выше суммы рядов слоёв: справа стоит поле структурной сетки, ему
+    // нужна высота (поле до 64 строк — TextView доскроллит остаток)
+    // gw под 64 колонки канона: Menlo 11 ≈ 6.63 px/символ -> 424 px + рамка
+    // TextView + вертикальный скроллбар. QTextView не умеет отключать перенос,
+    // и на узком поле Qt переносит хвост строки — псевдографика рассыпается
+    gx = 954; gw = 480;
+    w  = gx + gw + 16;
+    h  = (by + 40 + 40).max(620);
+    gh = h - y0 - 100;
+    hasGrid = ~gridGenerate.notNil;
 
     // close previous window best-effort (reference may be a destroyed Qt
     // object; .close without try would abort the rebuild — same as tuner)
     if(~mixerWin.notNil) { try { ~mixerWin.close } };
     // reset all slots so nothing touches old widgets during the rebuild gap
-    ~mixerWin     = nil;
-    ~mixerGuiSync = nil;
-    ~mixerEz      = ();
-    ~mixerSoloBtn = ();
-    ~mixerRecBtn  = nil;
+    ~mixerWin        = nil;
+    ~mixerGuiSync    = nil;
+    ~mixerEz         = ();
+    ~mixerSoloBtn    = ();
+    ~mixerRecBtn     = nil;
+    ~mixerGridTxt    = nil;
+    ~mixerGridStatus = nil;
+    ~mixerGridEz     = nil;
 
     win = Window(
         "UNGRUND · mixer — живое сведение слоёв (App)",
@@ -319,6 +338,58 @@ Ndef(\master).play(out: 0, numChannels: 2);
         .font_(Font("Menlo", 11))
         .action_({ win.close });
 
+    // --- структурная сетка (панель справа) ---
+    // панель nil-безопасна: без App/0_grid.scd кнопка выключена — тем же
+    // приёмом, что hasSpec у кнопки tuner
+    StaticText(~mixerWin, Rect(gx, 50, gw, 16))
+        .string_("структурная сетка — Ф/связи (канон structure-grid)")
+        .stringColor_(Color.gray(0.6)).font_(Font("Menlo", 9));
+
+    gridTv = TextView(~mixerWin, Rect(gx, y0, gw, gh))
+        .font_(Font("Menlo", 11))
+        .editable_(false)
+        .background_(Color.gray(0.08))
+        .stringColor_(Color.gray(0.88));
+    ~mixerGridTxt = gridTv;
+
+    gridEz = EZSlider(~mixerWin, Rect(gx, h - 96, gw, 24), "сложность",
+        ControlSpec(0, 1, \lin, 0, ~gridComplexity ? 0.5),
+        // слайдер только пишет ~gridComplexity: перерисовывать поле на каждый
+        // пиксель движения незачем, структуру строит кнопка
+        { |ez| ~gridComplexity = ez.value }, ~gridComplexity ? 0.5);
+    gridEz.round_(0.01);
+    ~mixerGridEz = gridEz;
+
+    gridStatus = StaticText(~mixerWin, Rect(gx, h - 36, gw, 20))
+        .stringColor_(Color.gray(0.6)).font_(Font("Menlo", 10));
+    ~mixerGridStatus = gridStatus;
+
+    gridBtn = Button(~mixerWin, Rect(gx, h - 66, 150, 24))
+        .states_([["сгенерировать", Color.white, Color(0.18, 0.34, 0.44)]])
+        .font_(Font("Menlo", 11, true))
+        .action_({
+            var g = ~gridGenerate.(~gridComplexity ? 0.5);
+            if(g.isNil) {
+                gridStatus.string_(
+                    "отказ: не разложилось за " ++ ~cfg_grid.graphTries ++ " графов"
+                );
+            } {
+                gridTv.string_(g[\text]);
+                gridStatus.string_(
+                    "Ф: " ++ g[\nodes] ++ " · поле: " ++ g[\cols] ++ "×" ++ g[\rows]
+                );
+            };
+        });
+
+    if(hasGrid) {
+        gridStatus.string_("сложность -> кнопка; поле выделяется и копируется");
+    } {
+        gridBtn.states_([["сетка —", Color.gray(0.4), Color.gray(0.18)]])
+            .enabled_(false);
+        gridEz.enabled_(false);
+        gridStatus.string_("модуль сетки не загружен (App/0_grid.scd)");
+    };
+
     // GUI sync hook <- ~mixSet/~masterSet
     ~mixerGuiSync = { |layer, which, v|
         {
@@ -337,11 +408,14 @@ Ndef(\master).play(out: 0, numChannels: 2);
     // would wipe slots registered by the NEW one (same trap as the tuner)
     win.onClose_({
         if(~mixerWin.isNil or: { ~mixerWin === win }) {
-            ~mixerGuiSync = nil;
-            ~mixerEz      = ();
-            ~mixerSoloBtn = ();
-            ~mixerRecBtn  = nil;
-            ~mixerWin     = nil;
+            ~mixerGuiSync    = nil;
+            ~mixerEz         = ();
+            ~mixerSoloBtn    = ();
+            ~mixerRecBtn     = nil;
+            ~mixerGridTxt    = nil;
+            ~mixerGridStatus = nil;
+            ~mixerGridEz     = nil;
+            ~mixerWin        = nil;
         };
     });
     win.front;

--- a/App/3_lfo.scd
+++ b/App/3_lfo.scd
@@ -8,8 +8,8 @@
 (
 // Each line: ( target: \layer, param: \name, shape: \sine|\tri|\noise|\noise0,
 //              rate: Hz, min: lo, max: hi )
-// target may also be the mixer: \mix_<layer> param \vol, or the send
-// aggregator \fxsend param \send_<layer> (see 2_mixer.scd).
+// target may also be the mixer: \mix_<layer> param \vol, or a send
+// aggregator \fxsendRev / \fxsendDly param \send_<layer> (see 2_mixer.scd).
 ~cfg_lfo = (
     lines: [
         // alpha: very slow volume breathing (§C.1)
@@ -25,7 +25,7 @@
         ( target: \theta,   param: \lfnRate, shape: \tri,   rate: 0.02, min: 0.08, max: 0.16 ),
 
         // mixer: slow breathing of theta's reverb send
-        ( target: \fxsend, param: \send_theta, shape: \sine, rate: 0.025, min: 0.45, max: 0.70 )
+        ( target: \fxsendRev, param: \send_theta, shape: \sine, rate: 0.025, min: 0.45, max: 0.70 )
     ]
 );
 

--- a/App/5_control.scd
+++ b/App/5_control.scd
@@ -6,7 +6,7 @@
 
 // ===== CONFIG — edit here ============================================
 (
-// Each line: ( cc: N, type: \layer|\mixVol|\mixSend|\lfoRate|\master,
+// Each line: ( cc: N, type: \layer|\mixVol|\mixSendRev|\mixSendDly|\lfoRate|\master,
 //              target: \layer (or lfo index for \lfoRate),
 //              param: \name (only for type \layer), min: lo, max: hi )
 ~cfg_ctrl = (
@@ -15,7 +15,7 @@
         ( cc: 1,  type: \mixVol,  target: \alpha,            min: 0.0,  max: 1.0 ),
         ( cc: 7,  type: \master,                              min: 0.0,  max: 1.0 ),
         ( cc: 21, type: \layer,   target: \delta, param: \freq, min: 100, max: 2000 ),
-        ( cc: 22, type: \mixSend, target: \theta,            min: 0.0,  max: 1.0 ),
+        ( cc: 22, type: \mixSendRev, target: \theta,          min: 0.0,  max: 1.0 ),
         ( cc: 23, type: \layer,   target: \epsilon, param: \freqHi, min: 300, max: 2000 ),
         ( cc: 24, type: \lfoRate, target: 0,                  min: 0.005, max: 0.2 )
     ]
@@ -38,11 +38,12 @@ MIDIdef.cc(\ung_cc, { |val, num, chan|
     if(line.notNil and: { ~cfg_ctrl.channel.isNil or: { chan == ~cfg_ctrl.channel } }) {
         var v = ~ctrlScale.(val, line.min, line.max);
         switch(line.type,
-            \mixVol,  { ~mixSet.(line.target, \vol, v) },
-            \mixSend, { ~mixSet.(line.target, \send, v) },
-            \master,  { ~masterSet.(v) },
-            \layer,   { Ndef(line.target.asSymbol).set(line.param, v) },
-            \lfoRate, {
+            \mixVol,     { ~mixSet.(line.target, \vol, v) },
+            \mixSendRev, { ~mixSet.(line.target, \sendRev, v) },
+            \mixSendDly, { ~mixSet.(line.target, \sendDly, v) },
+            \master,     { ~masterSet.(v) },
+            \layer,      { Ndef(line.target.asSymbol).set(line.param, v) },
+            \lfoRate,    {
                 // ~lfoKeys exists only if 3_lfo is loaded — ignore silently
                 if(~lfoKeys.notNil) {
                     var lfoKey = ~lfoKeys.detect { |k|

--- a/App/6_effects.scd
+++ b/App/6_effects.scd
@@ -1,6 +1,7 @@
 // App/6_effects.scd — UNGRUND · EFFECTS (§K reference_v2): \tape_reverb
-// (§K.1) and \ping_delay (§K.2) read ~busFxSend in parallel and write
-// their returns to ~busFxReturn (read by the master in 2_mixer.scd).
+// (§K.1) reads ~busFxSendRev, \ping_delay (§K.2) reads ~busFxSendDly —
+// separate buses, so the §K.1/§K.2 send tables stay independent. Both
+// write their returns to ~busFxReturn (read by the master in 2_mixer.scd).
 // Buses are created by 1_app.scd.
 
 
@@ -25,7 +26,7 @@
 // --- K.1  tape reverb -------------------------------------------------
 Ndef(\tape_reverb, { |wet = 0.85, decay = 0.95, rolloff = 3500|
     var sig, ratesL, ratesR, diffL, diffR, combL, combR, roll;
-    sig    = InFeedback.ar(~busFxSend.index, 2);
+    sig    = InFeedback.ar(~busFxSendRev.index, 2);
     sig    = DelayC.ar(sig, 0.05, 0.012);
     ratesL = [0.17, 0.24, 0.19, 0.31];
     ratesR = [0.21, 0.16, 0.28, 0.23];
@@ -47,7 +48,7 @@ Ndef(\tape_reverb, { |wet = 0.85, decay = 0.95, rolloff = 3500|
 // --- K.2  ping-pong delay ---------------------------------------------
 Ndef(\ping_delay, { |wet = 0.5, timeL = 0.37, timeR = 0.53, fb = 0.55, lpf = 1800|
     var in, dL, dR, sig;
-    in = InFeedback.ar(~busFxSend.index, 2);
+    in = InFeedback.ar(~busFxSendDly.index, 2);
     in = Mix(in) * 0.5;                              // mono into the ping-pong
     dL = LocalIn.ar(2);
     // L gets input + decayed right tail; R gets the left tail


### PR DESCRIPTION
Генератор структурных сеток по канону `docs/architecture/structure-grid/README.md` и панель в окне микшера: поле CP437-псевдографики, кнопка «сгенерировать» и слайдер «сложность».

## Что внутри

- **`App/0_grid.scd`** (новый) — генератор. Граф по рангам сверху вниз, сила связей по правилу 6, раскладка со сглаживанием, растеризация углами и сегментами с проверкой коллизий. Чистая логика, сервер не нужен. API: `~gridGenerate.(complexity)` / `~gridRender.(grid)`.
- **`App/1_app.scd`** — грузит `0_grid.scd` шагом 0a, до микшера (панель читает `~gridGenerate`).
- **`App/2_mixer.scd`** — панель справа от рядов слоёв. Окно 1450×620. Панель nil-безопасна: без `0_grid.scd` кнопка выключена.

Слайдер «сложность» 0..1 гонит число Ф (5→24), вероятности ветвления (0.15→0.60) и схождения (0.10→0.50), потолок ширины фронта (3→5) и размер поля (16→64).

Канон соблюдается по построению, а не проверками задним числом: единственный корень с ровно одной первой связью (правило 2), чередование Ф—С—Ф, рёбра только вниз (отсюда ацикличность), последний фронт — листья (правило 5). Тройники, кресты и переходные символы не используются — канон их резервирует, поэтому пересечение связей нечем нарисовать и оно ловится как коллизия с перегенерацией.

## Проверка

`parse_check` чист на всех трёх файлах.

Замерено независимо, по 500 структур на каждую из сложностей 0 / 0.25 / 0.5 / 0.75 / 1.0:

| Метрика | Результат |
|---|---|
| корень ветвится (правило 2 → должно быть 0) | **0/500** на всех сложностях |
| структур без сильной связи (правило 6: ствол силён) | **0/500** на всех сложностях |
| нарушений канона в растре (алфавит, правило 3, оборванные связи) | **0/500** |
| отказов генератора | **0** |
| макс. занятая колонка при сложности 1.0 | 62 при поле 64 |

## Ревью и правки

Ревью нашло два нарушения канона, оба починены и перепроверены замерами:

- **H1** — корень мог ветвиться, из-за чего ствол оказывался пуст и структура рисовалась целиком одинарными линиями (14–15% при низкой сложности). Корню жёстко задан outdegree 1.
- **H2** — тихий отбор выборки: при фиксированном шаге рангов поле не вмещало «стволовые» графы, ретрай молча выбрасывал их и подменял широкими. При сложности 0 отбраковывалось 60.8% графов, и все 243 из 243 — с неветвящимся корнем; корень ветвился у 42% принятых против 15% на графе. Шаг рангов теперь выводится из числа рангов графа, а непроводимые широкие фронты объявлены в CONFIG (`maxFront`) вместо того, чтобы отбраковываться молча. Перекос по распределению рангов упал с 62.3% до 0–4.4%.

Плюс ширина панели (поле в 64 колонки не влезало в 410 px и Qt рассыпал псевдографику мягким переносом) и `rrand(2, cap)`, возвращавший 2 при `cap == 1`.

Панель проверена в SC IDE: отображается, генерация работает.

## Известные ограничения

- **Остаточный отбор на высоких сложностях.** При сложности 1.0 растеризатор принимает с первой попытки 206 графов из 500; отказов у пользователя нет за счёт ретраев, но распределение рангов среди принятых отклоняется на ~4.4% (при 0.0% на низких сложностях). Упирается в природу разводки только углами без пересечений.
- **Привязки к звуку нет** — канон сопоставление Ф с функциями композиции на этом этапе не фиксирует, панель чисто визуальная.
- `branchProb` оставлен на 0.60; после введения `maxFront` верхние 0.75 могут снова быть проходимы — вопрос плотности, к композитору.

Первый коммит ветки (`f96b3dc`) — рефакторинг §K на две шины посылов, он был в дереве до этой работы и лежит отдельно.
